### PR TITLE
fix: use the cron based trigger for gh pages publish action

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -5,9 +5,8 @@
 
 name: Publish Github Pages
 on:
-  push:
-    branches:
-      - master
+  schedule:
+    - cron: "0 */1 * * *" # every hour
   workflow_dispatch:
 jobs:
   action:


### PR DESCRIPTION
fix: use the cron-based trigger for gh pages publish action

Ref: https://github.com/chatwoot/chatwoot-contributors/pull/5